### PR TITLE
Add Admin Mode: teacher login + protected register/unregister

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -9,6 +9,10 @@
   <body>
     <header>
       <h1>Mergington High School</h1>
+      <div id="user-controls">
+        <button id="login-btn" class="icon-btn" title="Teacher Login">👤</button>
+        <button id="logout-btn" class="icon-btn hidden" title="Logout">↩︎</button>
+      </div>
       <h2>Extracurricular Activities</h2>
     </header>
 
@@ -44,6 +48,28 @@
     <footer>
       <p>&copy; 2023 Mergington High School</p>
     </footer>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-username">Username</label>
+            <input type="text" id="login-username" required />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password</label>
+            <input type="password" id="login-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="login-cancel">Cancel</button>
+          </div>
+          <div id="login-message" class="hidden"></div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,6 +22,28 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
+}
+/* User controls in header */
+#user-controls {
+  position: absolute;
+  right: 16px;
+  top: 16px;
+  display: flex;
+  gap: 8px;
+}
+
+.icon-btn {
+  background: rgba(255,255,255,0.15);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 20px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background: rgba(255,255,255,0.25);
 }
 
 header h1 {
@@ -190,6 +212,39 @@ button:hover {
 
 .hidden {
   display: none;
+}
+/* Modal styles */
+.modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 360px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 10px;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    { "username": "alice", "password": "teach123" },
+    { "username": "bob", "password": "secure456" }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements Admin Mode per issue #5:
- JSON-backed teacher credentials in `src/teachers.json` (plaintext for exercise)
- Session-based auth with `/auth/login` and `/auth/logout`
- Protects `/activities/{name}/signup` and `.../unregister` with teacher login (403 otherwise)
- Frontend login UI (header controls + modal) and conditional actions
- CSS fix: ensure modal closes correctly (`.modal.hidden` override)

## Rationale
Prevents students from unregistering each other and centralizes control to teachers, matching the requested behavior while keeping complexity low (no DB).

## Testing
- Manual: login as `alice / teach123`, register/unregister should work; cancel/login properly closes modal.
- Without login: signup/unregister returns 403 and UI blocks actions.

## Notes
- This is a simple session store kept in-memory; acceptable for exercise/demo but not production-grade.
- Credentials are plaintext per request; a future improvement would hash these and persist sessions.

Resolves #5